### PR TITLE
Fix author-year citations.

### DIFF
--- a/sigplanconf-pldi16.cls
+++ b/sigplanconf-pldi16.cls
@@ -338,7 +338,7 @@
                      \@setflag \@ninepoint = \@false
                      \@setflag \@tenpoint = \@true
                      \@setflag \@explicitsize = \@true
-		     \@setflag \@authoryear = \@false
+		     \@setflag \@authoryear = \@true
                      \@setflag \@squareay = \@true
                      \@setflag \@blind = \@true
                      \@setflag \@preprint = \@true


### PR DESCRIPTION
Numeric citations were used even if `pldiauthoryear` option was provided.
